### PR TITLE
refactor(memcache): use Err method instead of Done channel

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -273,11 +273,9 @@ func (c *Client) dial(addr net.Addr) (net.Conn, error) {
 }
 
 func (c *Client) getConn(ctx context.Context, addr net.Addr) (*conn, error) {
-	// Check if the context is expired.
-	select {
-	default:
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	// Check if the context is done.
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
 	cn, ok := c.getFreeConn(addr)


### PR DESCRIPTION
It is better to use Err method to check if Done is closed.

https://github.com/golang/go/blob/master/src/context/context.go#L101-L102

```
If Done is not yet closed, Err returns nil.
If Done is closed, Err returns a non-nil error explaining why
```